### PR TITLE
Add bundle default require file (autorequire deprecated)

### DIFF
--- a/lib/sinatra/advanced/routes.rb
+++ b/lib/sinatra/advanced/routes.rb
@@ -1,0 +1,1 @@
+require 'sinatra/advanced_routes'


### PR DESCRIPTION
Otherwise everyone must set in gemfile :require => 'sinatra/advanced_routes'
