### PR TITLE
Travis: Only build for latest stable releases (2.3.1 and 2.2.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - rbx-18mode
-  - rbx-19mode
-  - jruby-18mode
-  - jruby-19mode
+  - 2.2.5
+  - 2.3.1
   - jruby-head
   - ruby-head
+
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,35 +7,40 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.3.0)
-    diff-lcs (1.2.3)
-    eventmachine (1.0.3)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    backports (3.6.8)
+    diff-lcs (1.2.5)
+    multi_json (1.12.1)
+    rack (1.6.4)
+    rack-protection (1.5.3)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
-    sinatra (1.4.2)
-      rack (~> 1.5, >= 1.5.2)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    sinatra-contrib (1.4.0)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
       backports (>= 2.0)
-      eventmachine
+      multi_json
       rack-protection
       rack-test
-      sinatra (~> 1.4.2)
-      tilt (~> 1.3)
-    tilt (1.3.7)
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.5)
 
 PLATFORMS
   ruby
@@ -46,3 +51,6 @@ DEPENDENCIES
   rspec (>= 1.3.0)
   sinatra-advanced-routes!
   sinatra-contrib
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
Since this gem hasn't really been updated for a while, there are still builds listed for old, EOLed versions of Ruby. (1.8, 1.9 are all no longer maintained)

The commit in this PR removes those old builds and adds 2.2.5 and 2.3.1, while keeping the jruby-head and ruby-head builds.

This commit also resolves a style error with no newline at the end of the file.